### PR TITLE
fix(mappings): 🐛 update key mappings for vim-tmux-navigator

### DIFF
--- a/mappings.lua
+++ b/mappings.lua
@@ -40,6 +40,17 @@ M.neoclip = {
   },
 }
 
+-- Vim-tmux-navigator mappings
+M.vimtmuxnavigator = {
+  n = {
+    ["<C-h>"] = { "<cmd>TmuxNavigateLeft<CR>", "Navigate Left" },
+    ["<C-j>"] = { "<cmd>TmuxNavigateDown<CR>", "Navigate Down" },
+    ["<C-k>"] = { "<cmd>TmuxNavigateUp<CR>", "Navigate Up" },
+    ["<C-l>"] = { "<cmd>TmuxNavigateRight<CR>", "Navigate Right" },
+    ["<C-\\>"] = { "<cmd>TmuxNavigatePrevious<CR>", "Navigate Previous" },
+  },
+}
+
 M.dap = {
   plugin = true,
   n = {

--- a/plugins.lua
+++ b/plugins.lua
@@ -79,20 +79,13 @@ local plugins = {
     },
   },
   {
-  "christoomey/vim-tmux-navigator",
+    "christoomey/vim-tmux-navigator",
     cmd = {
       "TmuxNavigateLeft",
       "TmuxNavigateDown",
       "TmuxNavigateUp",
       "TmuxNavigateRight",
       "TmuxNavigatePrevious",
-    },
-    keys = {
-      { "<c-h>", "<cmd><C-U>TmuxNavigateLeft<cr>" },
-      { "<c-j>", "<cmd><C-U>TmuxNavigateDown<cr>" },
-      { "<c-k>", "<cmd><C-U>TmuxNavigateUp<cr>" },
-      { "<c-l>", "<cmd><C-U>TmuxNavigateRight<cr>" },
-      { "<c-\\>", "<cmd><C-U>TmuxNavigatePrevious<cr>" },
     },
   },
   {


### PR DESCRIPTION
## Pull Request: 🐛 Fix Navigation Between Neovim and tmux

👤 **My Journey to Seamless Navigation**
Navigating between Neovim and tmux is a cornerstone of my daily workflow, enabling me to switch effortlessly between code editing and terminal operations. However, I recently encountered a snag where my key mappings for `christoomey/vim-tmux-navigator` were not being applied as expected, disrupting this seamless navigation.

🔍 **Navigational Quirk Resolution**
- **Key Mappings Update**:
  - The essence of the issue was that the Ctrl+h/j/k/l key bindings, which I depend on for moving between Neovim splits and tmux panes, were not functioning correctly. After some troubleshooting, I identified the misconfiguration in my `mappings.lua` file and implemented the necessary corrections. This update restores the fluid navigation I've come to rely on, ensuring that I can move between my editor and terminal with the expected ease. (Commit: a5f4a2269ce68d78eb0c6ab930c0e59b5c7508b9)
- **Restoring Harmony Between Neovim and tmux**:
  - Rectifying the key mappings has reinstated the intuitive and efficient interaction between Neovim and tmux, crucial for maintaining momentum during development tasks. This fix highlights my commitment to a seamless development environment where tools work in unison, not in conflict.
- **Refinement of My Development Setup**:
  - Addressing this hiccup is a testament to my ongoing efforts to refine and perfect my setup. Ensuring that every component operates harmoniously is paramount to achieving a frictionless development experience that aligns with my navigation habits and workflow needs.

### 🌟 Enhanced Development Experience
- **Navigation Efficiency Restored**: Correcting the key mappings has eliminated the navigation disruption, allowing me to maintain my focus and efficiency without missing a beat.
- **Workflow Intuitiveness Enhanced**: With the mappings now correctly applied, my workflow has regained its intuitiveness, affording me the luxury of concentrating on coding rather than navigating between tools.

### 🧪 My Approach to Validation
- I meticulously tested the updated key mappings across various Neovim and tmux scenarios, ensuring that the Ctrl+h/j/k/l keys performed as anticipated, thus validating the effectiveness of the fix.
- Confirming the restored functionality not only solved the immediate issue but also reinforced my dedication to maintaining a highly functional and integrated development environment.

## 🌳 Branch
`fix/vim-tmux-navigator-mappings`